### PR TITLE
remove maintainer who hasn't accepted invite for >3yrs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,4 +58,3 @@ about:
 extra:
   recipe-maintainers:
     - basnijholt
-    - AdriaanRol


### PR DESCRIPTION
This stops frequent notifications, such as https://github.com/conda-forge/qcodes-feedstock/commit/c95592c0022fd295c6a2f077b51f18b6b969e453#commitcomment-38512574.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
