### PR TITLE
fix links to qcodes docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ About qcodes-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/qcodes-feedstock/blob/main/LICENSE.txt)
 
-Home: http://qcodes.github.io/Qcodes
+Home: http://microsoft.github.io/Qcodes
 
 Package license: MIT
 
 Summary: Modular data acquisition and analysis framework
 
-Development: https://github.com/QCoDeS/Qcodes
+Development: https://github.com/microsoft/Qcodes
 
-Documentation: http://qcodes.github.io/Qcodes
+Documentation: http://microsoft.github.io/Qcodes
 
 QCoDeS is a Python-based data acquisition framework developed
 by the Copenhagen / Delft / Sydney / Microsoft quantum computing

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ about:
     to such experiments, and can be used anywhere a system with many
     degrees of freedom is controllable by computer.
   doc_url: http://microsoft.github.io/Qcodes
-  dev_url: https://github.com/QCoDeS/Qcodes
+  dev_url: https://github.com/microsoft/Qcodes
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2295bf96991c30307af439f7fa5d4b612e397b13a7b5ca89868f95cf70c406a3
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<=38]
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -57,7 +57,7 @@ test:
     - qcodes
 
 about:
-  home: http://qcodes.github.io/Qcodes
+  home: http://microsoft.github.io/Qcodes
   license: MIT
   license_file: LICENSE
   summary: Modular data acquisition and analysis framework
@@ -68,7 +68,7 @@ about:
     nanoelectronic device experiments, it is not inherently limited
     to such experiments, and can be used anywhere a system with many
     degrees of freedom is controllable by computer.
-  doc_url: http://qcodes.github.io/Qcodes
+  doc_url: http://microsoft.github.io/Qcodes
   dev_url: https://github.com/QCoDeS/Qcodes
 
 extra:


### PR DESCRIPTION
Reflecting the fact that qocdes has moved to microsoft org

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
