### PR TITLE
Convert qcodes-feedstock to v1 feedstock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -61,7 +71,7 @@ ulimit -n 1024
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
 fi
 
 
@@ -72,20 +82,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,34 +9,24 @@ set -xe
 MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
 MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
 export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
-
-( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
-MICROMAMBA_VERSION="1.5.10-0"
-if [[ "$(uname -m)" == "arm64" ]]; then
-  osx_arch="osx-arm64"
-else
-  osx_arch="osx-64"
+( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p "${MINIFORGE_HOME}"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
 fi
-MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
-MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
-echo "Downloading micromamba ${MICROMAMBA_VERSION}"
-micromamba_exe="$(mktemp -d)/micromamba"
-curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
-chmod +x "${micromamba_exe}"
+sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
 echo "Creating environment"
-"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
-  --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
-mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
-echo "Cleaning up micromamba"
-rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
-( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+( endgroup "Provisioning base env with pixi" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-echo "Activating environment"
-source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
-conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
@@ -70,33 +60,25 @@ source run_conda_forge_build_setup
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 
-echo -e "\n\nMaking the build clobber file"
-make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build does not currently support debug mode"
 else
 
     if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
     fi
 
-    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
-        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+    rattler-build build --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="$flow_run_id" \
+        --extra-meta remote_url="$remote_url" \
+        --extra-meta sha="$sha"
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -13,36 +13,46 @@
 setlocal enableextensions enabledelayedexpansion
 
 FOR %%A IN ("%~dp0.") DO SET "REPO_ROOT=%%~dpA"
-if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
+if "%MINIFORGE_HOME%"=="" (
+    set "MINIFORGE_HOME=%REPO_ROOT%\.pixi\envs\default"
+) else (
+    set "PIXI_CACHE_DIR=%MINIFORGE_HOME%"
+)
 :: Remove trailing backslash, if present
 if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
-call :start_group "Provisioning base env with micromamba"
-set "MAMBA_ROOT_PREFIX=%MINIFORGE_HOME%-micromamba-%RANDOM%"
-set "MICROMAMBA_VERSION=1.5.10-0"
-set "MICROMAMBA_URL=https://github.com/mamba-org/micromamba-releases/releases/download/%MICROMAMBA_VERSION%/micromamba-win-64"
-set "MICROMAMBA_TMPDIR=%TMP%\micromamba-%RANDOM%"
-set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
-
-echo Downloading micromamba %MICROMAMBA_VERSION%
-if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+call :start_group "Provisioning base env with pixi"
+echo Installing pixi
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "iwr -useb https://pixi.sh/install.ps1 | iex"
 if !errorlevel! neq 0 exit /b !errorlevel!
-
-echo Creating environment
-call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
-    --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+set "PATH=%USERPROFILE%\.pixi\bin;%PATH%"
+echo Installing environment
+if "%PIXI_CACHE_DIR%"=="%MINIFORGE_HOME%" (
+    mkdir "%MINIFORGE_HOME%"
+    copy /Y pixi.toml "%MINIFORGE_HOME%"
+    pushd "%MINIFORGE_HOME%"
+) else (
+    pushd "%REPO_ROOT%"
+)
+move /y pixi.toml pixi.toml.bak
+set "arch=64"
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "(Get-Content pixi.toml.bak -Encoding UTF8) -replace 'platforms = .*', 'platforms = [''win-%arch%'']' | Out-File pixi.toml -Encoding UTF8"
+pixi install
 if !errorlevel! neq 0 exit /b !errorlevel!
-echo Removing %MAMBA_ROOT_PREFIX%
-del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
-del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+pixi list
+if !errorlevel! neq 0 exit /b !errorlevel!
+set "ACTIVATE_PIXI=%TMP%\pixi-activate-%RANDOM%.bat"
+pixi shell-hook > "%ACTIVATE_PIXI%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+call "%ACTIVATE_PIXI%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+move /y pixi.toml.bak pixi.toml
+popd
 call :end_group
 
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
-echo Activating environment
-call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"
 if !errorlevel! neq 0 exit /b !errorlevel!
@@ -64,19 +74,19 @@ if EXIST LICENSE.txt (
 )
 if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
     if [%CROSSCOMPILING_EMULATOR%] == [] (
-        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --test skip"
     )
 )
 
 if NOT [%flow_run_id%] == [] (
-        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% remote_url=%remote_url% sha=%sha%"
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% --extra-meta remote_url=%remote_url% --extra-meta sha=%sha%"
 )
 
 call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+rattler-build.exe build --recipe "recipe" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --target-platform %HOST_PLATFORM%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 call :start_group "Inspecting artifacts"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ nanoelectronic device experiments, it is not inherently limited
 to such experiments, and can be used anywhere a system with many
 degrees of freedom is controllable by computer.
 
-
 Current build status
 ====================
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,5 @@ github:
   branch_name: main
   tooling_branch_name: main
 test: native_and_emulated
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,64 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+[project]
+name = "qcodes-feedstock"
+version = "3.46.0"
+description = "Pixi configuration for conda-forge/qcodes-feedstock"
+authors = ["@conda-forge/qcodes"]
+channels = ["conda-forge"]
+platforms = ['linux-64', 'osx-64', 'win-64']
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+inspect-all = "inspect_artifacts --all-packages"
+build = "rattler-build build --recipe recipe"
+"build-linux_64_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
+"inspect-linux_64_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
+"build-linux_64_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
+"inspect-linux_64_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
+"build-linux_64_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
+"inspect-linux_64_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
+"build-linux_64_python3.13.____cp313" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
+"inspect-linux_64_python3.13.____cp313" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
+"build-osx_64_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
+"inspect-osx_64_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
+"build-osx_64_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
+"inspect-osx_64_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
+"build-osx_64_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
+"inspect-osx_64_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
+"build-osx_64_python3.13.____cp313" = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
+"inspect-osx_64_python3.13.____cp313" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
+"build-osx_arm64_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
+"inspect-osx_arm64_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
+"build-osx_arm64_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
+"inspect-osx_arm64_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
+"build-osx_arm64_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
+"inspect-osx_arm64_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
+"build-osx_arm64_python3.13.____cp313" = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
+"inspect-osx_arm64_python3.13.____cp313" = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
+"build-win_64_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.10.____cpython.yaml"
+"inspect-win_64_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.10.____cpython.yaml"
+"build-win_64_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.11.____cpython.yaml"
+"inspect-win_64_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.11.____cpython.yaml"
+"build-win_64_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.12.____cpython.yaml"
+"inspect-win_64_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.12.____cpython.yaml"
+"build-win_64_python3.13.____cp313" = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.13.____cp313.yaml"
+"inspect-win_64_python3.13.____cp313" = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.13.____cp313.yaml"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+
+[feature.smithy.tasks]
+build-locally = "python ./build-locally.py"
+smithy = "conda-smithy"
+rerender = "conda-smithy rerender"
+lint = "conda-smithy lint recipe"
+
+[environments]
+smithy = ["smithy"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,23 +1,29 @@
-{% set name = "qcodes" %}
-{% set version = "0.51.0" %}
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/73cd2eed94c576213c5f25ab57adf6d8c83e792a/schema.json
+schema_version: 1
+
+context:
+  name: qcodes
+  version: 0.51.0
 
 package:
   name: qcodes
-  version: {{ version }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: bde9a524adfe0640e6f84ab0e007b4d0c3fca8e7bb8c276db22562dc9467855e
 
 build:
-  number: 0
-  skip: true  # [py<=39]
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  skip: match(python, "<=3.9")
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - if: build_platform != target_platform
+      then: python
+    - if: build_platform != target_platform
+      then: cross-python_${{ target_platform }}
   host:
     - python
     - pip
@@ -31,8 +37,10 @@ requirements:
     - websockets >=11.0
     - jsonschema >=4.9.0
     - ruamel.yaml >=0.16.0, !=0.16.6
-    - wrapt >=1.14.0  # [py<312]
-    - wrapt >=1.16.0  # [py>=312]
+    - if: match(python, "<3.12")
+      then: wrapt >=1.14.0
+    - if: match(python, ">=3.12")
+      then: wrapt >=1.16.0
     - pandas >=1.4.0
     - xarray >=2022.06.0
     - cf_xarray >=0.8.4
@@ -49,12 +57,12 @@ requirements:
     - dask >=2022.1.0
     - pillow >=9.0.0
 
-test:
-  imports:
-    - qcodes
+tests:
+  - python:
+      imports:
+        - qcodes
 
 about:
-  home: http://microsoft.github.io/Qcodes
   license: MIT
   license_file: LICENSE
   summary: Modular data acquisition and analysis framework
@@ -65,8 +73,9 @@ about:
     nanoelectronic device experiments, it is not inherently limited
     to such experiments, and can be used anywhere a system with many
     degrees of freedom is controllable by computer.
-  doc_url: http://microsoft.github.io/Qcodes
-  dev_url: https://github.com/microsoft/Qcodes
+  homepage: http://microsoft.github.io/Qcodes
+  repository: https://github.com/microsoft/Qcodes
+  documentation: http://microsoft.github.io/Qcodes
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts qcodes-feedstock to a v1 recipe and switch the conda build tool to rattler-build.It has been automatically generated with [feedrattler](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.